### PR TITLE
Fix icon colors in nav bar styling sample

### DIFF
--- a/samples/menus/nav-bar/styling/src/NavbarStyling.css
+++ b/samples/menus/nav-bar/styling/src/NavbarStyling.css
@@ -1,5 +1,5 @@
 igc-icon {
-    color: currentColor;
+    color: currentColor !important;
 }
 
 igc-navbar {


### PR DESCRIPTION
Before the fix the color of the icons was black.