### PR TITLE
fix(stepper): samples styling and validation issues

### DIFF
--- a/samples/layouts/stepper/linear/src/index.ts
+++ b/samples/layouts/stepper/linear/src/index.ts
@@ -42,7 +42,14 @@ export class StepperLinear {
             return;
         }
         const formControls = this.activeStep!.querySelectorAll("igc-radio, igc-input") as NodeListOf<any>;
-        const isFormInvalid = Array.from(formControls).some((control: IgcInputComponent | IgcRadioComponent) => !control.checkValidity());
+        const isFormInvalid = Array.from(formControls).some((control: IgcInputComponent | IgcRadioComponent) => {
+            const oldState = control.invalid;
+            // checks whether some of the form controls is not valid
+            const isControlInvalid = !control.checkValidity();
+            // restores the invalid state of the control
+            control.invalid = oldState;
+            return isControlInvalid;
+        });
 
         this.activeStep!.invalid = isFormInvalid;
         this.nextButton.disabled = this.stepper!.linear ? isFormInvalid : false;

--- a/samples/layouts/stepper/overview/src/StepperOverview.css
+++ b/samples/layouts/stepper/overview/src/StepperOverview.css
@@ -64,7 +64,7 @@
 }
 
 igc-card {
-    padding: 1rem;
+    padding: 1.5rem;
 }
 
 .card-wrapper.card-first-step {
@@ -113,11 +113,12 @@ igc-card-content p {
 igc-badge {
     position: absolute;
     z-index: 1;
-    top: -0.4rem;
+    top: -0.7rem;
     left: 0;
     right: 0;
     margin: 0 auto;
     width: fit-content;
+    padding: 0 0.2rem 0.2rem 0.2rem;
 }
 
 .card-wrapper igc-badge {

--- a/samples/layouts/stepper/overview/src/index.ts
+++ b/samples/layouts/stepper/overview/src/index.ts
@@ -22,7 +22,7 @@ import "./StepperOverview.css";
 const checkIcon =
     '<svg xmlns="http://www.w3.org/2000/svg" height="48" width="48"><path d="M21.05 33.1 35.2 18.95l-2.3-2.25-11.85 11.85-6-6-2.25 2.25ZM24 44q-4.1 0-7.75-1.575-3.65-1.575-6.375-4.3-2.725-2.725-4.3-6.375Q4 28.1 4 24q0-4.15 1.575-7.8 1.575-3.65 4.3-6.35 2.725-2.7 6.375-4.275Q19.9 4 24 4q4.15 0 7.8 1.575 3.65 1.575 6.35 4.275 2.7 2.7 4.275 6.35Q44 19.85 44 24q0 4.1-1.575 7.75-1.575 3.65-4.275 6.375t-6.35 4.3Q28.15 44 24 44Z"/></svg>';
 
-defineComponents(IgcStepperComponent, IgcRadioGroupComponent, IgcFormComponent, IgcSwitchComponent, IgcCardComponent, IgcBadgeComponent, IgcSelectComponent, IgcMaskInputComponent, IgcCheckboxComponent, IgcIconComponent);
+defineComponents(IgcStepperComponent, IgcButtonComponent, IgcRadioGroupComponent, IgcFormComponent, IgcSwitchComponent, IgcCardComponent, IgcBadgeComponent, IgcSelectComponent, IgcMaskInputComponent, IgcCheckboxComponent, IgcIconComponent);
 export class StepperOverview {
     private stepper: IgcStepperComponent;
     private taxIdInput: IgcMaskInputComponent;
@@ -117,7 +117,14 @@ export class StepperOverview {
     private checkValidity() {
         // checks validity of the input elements in the form
         const formControls = this.activeStep!.querySelectorAll("igc-radio, igc-input, igc-select, igc-mask-input, igc-checkbox") as NodeListOf<any>;
-        const isFormInvalid = Array.from(formControls).some((control: IgcInputComponent | IgcRadioComponent | IgcSelectComponent | IgcMaskInputComponent | IgcCheckboxComponent) => !control.checkValidity());
+        const isFormInvalid = Array.from(formControls).some((control: IgcInputComponent | IgcRadioComponent | IgcSelectComponent | IgcMaskInputComponent | IgcCheckboxComponent) => {
+            const oldState = control.invalid;
+            // checks whether some of the form controls is not valid
+            const isControlInvalid = !control.checkValidity();
+            // restores the invalid state of the control
+            control.invalid = oldState;
+            return isControlInvalid;
+        });
 
         this.activeStep!.invalid = isFormInvalid;
         if (this.nextButton) {
@@ -192,6 +199,15 @@ export class StepperOverview {
             this.stepper!.steps.forEach((step) => (step.invalid = true));
             document.querySelector(".selected-card")!.classList.remove("selected-card");
             document.querySelectorAll("igc-form").forEach((form) => form.reset());
+
+            // resets the invalid state of all form controls
+            requestAnimationFrame(() => {
+                const formControls = document.querySelectorAll("igc-radio, igc-input, igc-select, igc-mask-input, igc-checkbox") as NodeListOf<any>;
+                Array.from(formControls).forEach((control: IgcInputComponent | IgcRadioComponent | IgcSelectComponent | IgcMaskInputComponent | IgcCheckboxComponent) => {
+                    control.invalid = false;
+                });
+            });
+
             this.businessInformation = {};
             this.personalInformation = {};
             this.shippingDetails = {};


### PR DESCRIPTION
Closes #346 
- position the "Your current choice" badge correctly in the first step of the Overview sample
- define the IgcButton component in the Overview sample
- restore the invalid state of the form controls in the Overview sample when the stepper is restored
- prevent highlighting the next invalid control in the Overview and Linear samples