### PR TITLE
fix(stepper): Remove an unnecessary backslash from the mask of a masked input

### DIFF
--- a/samples/layouts/stepper/overview/index.html
+++ b/samples/layouts/stepper/overview/index.html
@@ -39,8 +39,8 @@
                                     </igc-select>
                                     <igc-mask-input required label="ZIP Code" placeholder="#####" name="zip" mask="00000"> </igc-mask-input>
                                 </div>
-                                <igc-checkbox id="different-mailing-address"> The mailing address is different than the business physical address </igc-checkbox>
-                                <igc-mask-input id="tax-id" value-mode="withFormatting" required label="Federal Tax Id Number" placeholder="9##-##-####" name="taxIdNumber" mask="\\900-00-0000"> </igc-mask-input>
+                                <igc-checkbox id="different-mailing-address">The mailing address is different than the business physical address</igc-checkbox>
+                                <igc-mask-input id="tax-id" value-mode="withFormatting" required label="Federal Tax Id Number" placeholder="9##-##-####" name="taxIdNumber" mask="\900-00-0000"> </igc-mask-input>
                                 <p id="tax-id-error-message" class="error-message hidden">The Federal Tax ID Number should begin with 9</p>
                                 <label>Does this business operate outside the United States?<span class="required">*</span></label>
                                 <igc-radio-group>


### PR DESCRIPTION
Closes #350 