### PR TITLE
fix(build): resolving an issue with sb samples racing condition

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,32 +5,54 @@ import { fileURLToPath } from 'node:url';
 import { existsSync } from 'node:fs';
 
 /**
- * Vite plugin: strip the module-level `new Sample();` (or `new ClassName();`)
- * from every sample src/index.ts.
+ * Vite plugin: keep the module-level `new Sample();` (or `new ClassName();`) of
+ * every sample src/index.ts, but only let it run on that sample's own page.
  *
  * WHY this is needed
  * ──────────────────
- * The `[...slug].astro` loader calls `new module.Sample()` explicitly after
- * the dynamic import resolves, so the page controls when a sample
- * instantiates.  Keeping the module-level `new Sample()` as well would run
- * every sample twice.  Stripping it here (instead of editing 900+ samples)
- * keeps each sample runnable standalone while the browser instantiates it
- * exactly once.
+ * Instantiation has to happen during module evaluation, exactly as it does in
+ * the standalone sample. The grids import defines the custom elements, the
+ * elements already in the page upgrade and start rendering, and the grid
+ * raises one-shot events such as `rendered` on its first render. If the
+ * sample only runs after the dynamic import resolves, it attaches its
+ * listeners too late and those events are already gone: `expandAll()`, pinned
+ * rows and log panels set up in a `rendered` handler silently never happen.
+ *
+ * The guard is what keeps this safe. Rollup can hoist shared code into a
+ * sample chunk, so a *different* page may end up evaluating this module; the
+ * slug check stops it from instantiating a sample against a foreign DOM.
+ *
+ * The rewritten module exports `__sampleSelfInstantiated` so the
+ * `[...slug].astro` loader knows not to instantiate it a second time. Modules
+ * without a trailing `new X()` are left alone and the loader instantiates them.
  */
 /** @returns {import('vite').Plugin} */
-function stripSampleInstantiation() {
+function guardSampleInstantiation() {
   // Match the trailing `new ClassName();` that sample generators emit.
   // It is always the last non-empty statement in the file.
   const trailingNewRe = /\bnew\s+\w+\(\)\s*;?\s*$/;
 
   return {
-    name: 'strip-sample-instantiation',
+    name: 'guard-sample-instantiation',
     enforce: /** @type {'pre'} */ ('pre'),
     transform(code, id) {
       // Only touch samples/**/src/index.ts
-      if (!id.replace(/\\/g, '/').match(/\/samples\/.+\/src\/index\.ts$/)) return;
-      if (!trailingNewRe.test(code)) return;
-      return { code: code.replace(trailingNewRe, ''), map: null };
+      const match = id.replace(/\\/g, '/').match(/\/samples\/(.+)\/src\/index\.ts$/);
+      if (!match) return;
+
+      const trailing = code.match(trailingNewRe);
+      if (!trailing) return;
+
+      // Must match data-sample-slug, which [...slug].astro sets on <html>.
+      const slug = JSON.stringify(match[1]);
+      const call = trailing[0].trim().replace(/;?$/, ';');
+      const guarded = [
+        `if (document.documentElement.dataset.sampleSlug === ${slug}) { ${call} }`,
+        'export const __sampleSelfInstantiated = true;',
+        '',
+      ].join('\n');
+
+      return { code: code.replace(trailingNewRe, guarded), map: null };
     },
   };
 }
@@ -212,7 +234,7 @@ export default defineConfig({
   },
 
   vite: {
-    plugins: [resolveIgniteUiScoped(), stripSampleInstantiation(), inlineSampleCss()],
+    plugins: [resolveIgniteUiScoped(), guardSampleInstantiation(), inlineSampleCss()],
     // samples/ and node_modules/ are already at the repo root (__dirname),
     // so no extra fs.allow entries are needed.
     server: {

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -89,9 +89,11 @@ const pageTitle = `${info.displayName} | ${info.componentName} | Ignite UI Web C
 <!--
   Client-side sample loader.
   import.meta.glob registers all sample TS files as lazy Vite chunks at build time.
-  At runtime only the chunk matching the current slug is fetched and instantiated.
-  `new Sample()` is stripped at module level by the stripSampleInstantiation Vite
-  plugin, so we call it explicitly here against the page's own DOM.
+  At runtime only the chunk matching the current slug is fetched.
+  Samples normally instantiate themselves during module evaluation (see the
+  guardSampleInstantiation Vite plugin), so the grid's first-render events reach
+  their listeners. Only modules without a trailing `new Sample()` are
+  instantiated here, after the import resolves.
 -->
 <script>
   // Vite resolves this glob at build time → one lazy chunk per sample
@@ -115,9 +117,12 @@ const pageTitle = `${info.displayName} | ${info.componentName} | Ignite UI Web C
 
     if (sampleModules[moduleKey]) {
       sampleModules[moduleKey]().then((module) => {
-        const mod = module as Record<string, new () => unknown>;
+        const mod = module as Record<string, unknown>;
+        // Already instantiated while the module evaluated.
+        if (mod.__sampleSelfInstantiated) return;
+
         // Falls back to the first exported constructor if not named "Sample".
-        const SampleClass = mod['Sample'] ?? Object.values(mod).find(v => typeof v === 'function') as new () => unknown;
+        const SampleClass = (mod['Sample'] ?? Object.values(mod).find(v => typeof v === 'function')) as (new () => unknown) | undefined;
         if (SampleClass) {
           new SampleClass();
         } else {


### PR DESCRIPTION
Because of the new Sample() strip for the SB build, the replacement code causes a racing condition that leaves sample's constructors to fire after the grid is rendered and fired its rendered event (among other issues)

- astro.config.mjs] - new Sample() now runs inside the sample's module, straight after the grid package is imported, as it does in a standalone sample. A check against the page's slug keeps a shared chunk from starting the wrong sample on another page.
- [...slug].astro]: the loader only creates the sample for the 10 modules that don't do it themselves.